### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Install the compiled version into your frontend via `bower install skeleton-fram
 
 Install the latest development version via `git clone https://github.com/skeleton-framework/skeleton-framework.git`
 
-Contributions are welcome! Develoment docs can be found on the [wiki](https://github.com/skeleton-framework/skeleton-framework/wiki/Skeleton-Framework-Development)
+Contributions are welcome! Development docs can be found on the [wiki](https://github.com/skeleton-framework/skeleton-framework/wiki/Skeleton-Framework-Development)
 
 If you experience bugs or errors, please report it on the [issue tracker](https://github.com/skeleton-framework/skeleton-framework/issues)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Learn more at [skeleton-framework.github.io](http://skeleton-framework.github.io
 ## Usage
 Install the sources into your node app via `npm install skeleton-framework`.
 
-Install the compiled version into your frontend via `bower install skeleton-framework`.
+Install the compiled version into your frontend via `bower install skeletonframework`.
 
 Install the latest development version via `git clone https://github.com/skeleton-framework/skeleton-framework.git`
 


### PR DESCRIPTION
I was installing the package and installing via bower was not working. Apparently the package is available through bower as 'skeletonframework'; without the dash. I don't know if the package can be renamed, but in the meantime, editing the README will help users get started. 