### PR TITLE
fix font link on example page #53

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
         <title>Skeleton Framework Test File</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="skeleton.css">
         <link rel="icon" type="image/png" href="images/favicon.png">
 
@@ -690,7 +690,7 @@
                                     <h5>Text</h5>
                                     <p>Text</p>
                                     <div class="u-text-right">
-                                        <button class="button-primary">Nice Button</button>  
+                                        <button class="button-primary">Nice Button</button>
                                     </div>
                                 </div>
                             </div>
@@ -699,7 +699,7 @@
                                     <h5>Text</h5>
                                     <p>Text</p>
                                     <div class="u-text-right">
-                                        <button class="button-primary">Nice Button</button>  
+                                        <button class="button-primary">Nice Button</button>
                                     </div>
                                 </div>
                             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
         <title>Skeleton Framework Test File</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="skeleton.css">
         <link rel="icon" type="image/png" href="images/favicon.png">
 
@@ -690,7 +690,7 @@
                                     <h5>Text</h5>
                                     <p>Text</p>
                                     <div class="u-text-right">
-                                        <button class="button-primary">Nice Button</button>  
+                                        <button class="button-primary">Nice Button</button>
                                     </div>
                                 </div>
                             </div>
@@ -699,7 +699,7 @@
                                     <h5>Text</h5>
                                     <p>Text</p>
                                     <div class="u-text-right">
-                                        <button class="button-primary">Nice Button</button>  
+                                        <button class="button-primary">Nice Button</button>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
fix `//fonts.google..` by adding `https://fonts.google..`
so the font would be loaded when open the page by file directly