### PR TITLE
Remove invalid ASCII characters

### DIFF
--- a/src/core/_typography.css
+++ b/src/core/_typography.css
@@ -1,5 +1,4 @@
-/* Base Typo
- ------------------------------------------------- */
+/* Base Typo */
 
 h1,
 h2,
@@ -76,9 +75,7 @@ p {
   margin-top: 0;
 }
 
-
-/* Links
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+/* Links */
 
 a {
   color: var(--link-color);
@@ -88,8 +85,7 @@ a:hover {
   color: var(--link-color-hover);
 }
 
-/* Colors
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+/* Colors */
 .text-primary {
  color: var(--text-color-primary)
 }


### PR DESCRIPTION
To fix issue like: Invalid US-ASCII character "\xE2"

---

I'm currently trying to include skeleton with jekyll and I am facing this issue:

```
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
                    Invalid US-ASCII character "\xE2" on line 81
             Error: Invalid US-ASCII character "\xE2" on line 81
             Error: Run jekyll build --trace for more information.
```

This patch fix the issue.